### PR TITLE
Build for Debian trixie

### DIFF
--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [bullseye,bookworm]
+        distro: [trixie]
         arch: [arm64]
     
     steps:
@@ -37,7 +37,7 @@ jobs:
           path: ${{ steps.build-debian-package.outputs.deb-package }}
 
   slack-workflow-status:
-    if: always()
+    if: ${{ always() && github.repository_owner == 'WLAN-Pi' && ! github.event.pull_request.head.repo.fork }}
     name: Post Workflow Status to Slack
     needs:
       - sbuild

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [bullseye,bookworm]
+        distro: [trixie]
         arch: [arm64]
 
     environment: PACKAGECLOUD
@@ -62,7 +62,7 @@ jobs:
           packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
   slack-workflow-status:
-    if: always()
+    if: ${{ always() && github.repository_owner == 'WLAN-Pi' && ! github.event.pull_request.head.repo.fork }}
     name: Post Workflow Status to Slack
     needs:
       - sbuild

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+scandump (2.1.6) unstable; urgency=medium
+
+  * Rebuild to publish packages for Debian trixie to packagecloud.
+  * CI: build for trixie only and do not post to Slack from fork PRs
+    (secrets are unavailable there).
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Wed, 15 Jul 2026 02:51:58 -0400
+
 scandump (2.1.5) unstable; urgency=medium
 
   * Fixes issue when parsing the frequency argument.


### PR DESCRIPTION
Moves scandump's packaging to Debian trixie, matching the rest of the WLAN Pi package migration.

## Changes

- **CI matrix -> trixie only:** both `build-and-archive-debian-package.yml` and `deploy-to-packagecloud.yml` change `distro: [bullseye,bookworm]` to `distro: [trixie]`, so packages publish to `debian/trixie` on packagecloud.
- **Fork-guard the Slack job:** the `Post Workflow Status to Slack` job was `if: always()`, which fails from fork PRs where `SLACK_WEBHOOK_URL` is unavailable. Guarded with `always() && github.repository_owner == 'WLAN-Pi' && ! github.event.pull_request.head.repo.fork`.
- **Changelog 2.1.6:** the workflows trigger on `debian/changelog` changes; the bump fires the build/publish and avoids colliding with the existing 2.1.5 artifacts.

## Testing

Both workflows validated as YAML. Real build happens in CI on merge (or via `workflow_dispatch`). Expect a trixie/arm64 `.deb` published to `wlanpi/dev` `debian/trixie`.
